### PR TITLE
BUG - StackingERC721 unstake amount

### DIFF
--- a/contracts/StakingERC721.sol
+++ b/contracts/StakingERC721.sol
@@ -85,8 +85,8 @@ contract StakingERC721  {
         else
             tokens = tokenOwnershipB[msg.sender];
 
-        for(uint i = amount; i > 0; i--) {
-            uint256 id = tokens[i - 1];
+        for(uint i = 0; i < amount; i++) {
+            uint256 id = tokens[tokens.length - 1];
             tokens.pop();
             if(isTokenA)
                 tokenA.transferFrom(address(this), msg.sender, id);


### PR DESCRIPTION
# The Bug

When unstaking user is asked to fill an `amount` parameter, but the code does not take it into account:

```Solidity
function unstake(uint256 amount, bool isTokenA) external { // ask user for amount to unstake
  stakingContractEth.unstakeFrom(msg.sender, amount);

  uint256[] storage tokens;
  if(isTokenA)
    tokens = tokenOwnershipA[msg.sender];
  else
    tokens = tokenOwnershipB[msg.sender];

  for(uint i = tokens.length - 1; i > 0; i--) { // unstake every tokens no matter the amount specified by the user
    uint256 id = tokens[i];
    tokens.pop();
    if(isTokenA)
      tokenA.transferFrom(address(this), msg.sender, id);
    else
      tokenB.transferFrom(address(this), msg.sender, id);
  }
```

# Proposed Fix

We want to remove `amount` number of elements from the array. Because we use .pop(), we remove elements starting from the end of the array.

```Solidity
  for(uint i = 0; i < amount; i++) { // we run the loop 'amount' times (if amount > length, the function revert at the beginning)
    uint256 id = tokens[tokens.length - 1]; // retrieve the last elements before poping it
    tokens.pop();
    if(isTokenA)
      tokenA.transferFrom(address(this), msg.sender, id);
    else
      tokenB.transferFrom(address(this), msg.sender, id);
  }
```