### PR TITLE
BUG - AmplesenseVault

### DIFF
--- a/contracts/AmplesenseVault.sol
+++ b/contracts/AmplesenseVault.sol
@@ -11,6 +11,7 @@ import './interfaces/IStakingERC20.sol';
 import './EEFIToken.sol';
 import './AMPLRebaser.sol';
 import './interfaces/IBalancerTrader.sol';
+import 'hardhat/console.sol';
 
 contract AmplesenseVault is AMPLRebaser, Ownable {
     using SafeERC20 for IERC20;
@@ -167,9 +168,9 @@ contract AmplesenseVault is AMPLRebaser, Ownable {
             last_positive = block.timestamp;
             require(address(trader) != address(0), "AmplesenseVault: trader not set");
 
-            uint256 changeRatio18Digits = new_supply.sub(old_supply).mul(10**18).divDown(new_supply);
-            uint256 surplus = new_balance.mul(changeRatio18Digits).divDown(10**18);
-            
+            uint256 changeRatio18Digits = old_supply.mul(10**18).divDown(new_supply);
+            uint256 surplus = new_balance.sub(new_balance.mul(changeRatio18Digits).divDown(10**18));
+
             uint256 for_eefi = surplus.mul(TRADE_POSITIVE_EEFI_100).divDown(100);
             uint256 for_eth = surplus.mul(TRADE_POSITIVE_ETH_100).divDown(100);
             uint256 for_pioneer1 = surplus.mul(TRADE_POSITIVE_PIONEER1_100).divDown(100);
@@ -189,11 +190,13 @@ contract AmplesenseVault is AMPLRebaser, Ownable {
             emit Burn(to_burn);
             // buy eth and distribute
             trader.sellAMPLForEth(for_eth);
+            console.log("for eth", for_eth);
  
             uint256 to_rewards = address(this).balance.mul(TRADE_POSITIVE_REWARDS_100).divDown(100);
             uint256 to_pioneer2 = address(this).balance.mul(TRADE_POSITIVE_PIONEER2_100).divDown(100);
             uint256 to_pioneer3 = address(this).balance.mul(TRADE_POSITIVE_PIONEER3_100).divDown(100);
             uint256 to_lp_staking = address(this).balance.mul(TRADE_POSITIVE_LPSTAKING_100).divDown(100);
+            console.log("balance", address(this).balance, to_rewards);
             rewards_eth.distribute{value: to_rewards}(to_rewards, address(this));
             pioneer_vault2.distribute_eth{value: to_pioneer2}();
             pioneer_vault3.distribute_eth{value: to_pioneer3}();

--- a/contracts/tests/FakeAMPL.sol
+++ b/contracts/tests/FakeAMPL.sol
@@ -5,6 +5,7 @@ import 'uFragments/contracts/UFragments.sol';
 
 contract FakeAMPL is UFragments {
     constructor() UFragments() {
+        monetaryPolicy = msg.sender;
         initialize(msg.sender);
     }
 }

--- a/contracts/tests/MockTrader.sol
+++ b/contracts/tests/MockTrader.sol
@@ -11,8 +11,8 @@ contract MockTrader is IBalancerTrader {
 
     IERC20 public ampl_token;
     IERC20 public eefi_token;
-    uint256 ratio_eth = 1 ether;
-    uint256 ratio_eefi = 1 ether;
+    uint256 public ratio_eth = 1 ether;
+    uint256 public ratio_eefi = 1 ether;
 
     constructor(IERC20 _ampl_token, IERC20 _eefi_token, uint256 _ratio_eth, uint256 _ratio_eefi) {
         ampl_token = _ampl_token;


### PR DESCRIPTION
This PR fix 4 bugs in the `AmplesenseVault.sol`:

1. The contract was lacking a fallback function. This function was needed in order for the vault to receive eth (e.g. the trader try to send eth to the vault).

2. The constructor had a nasty bug :
```Solidity
constructor(IERC20 ampl_token)
    AMPLRebaser(ampl_token)
    Ownable() {
        rewards_eefi = new Distribute(9, IERC20(eefi_token)); // <--- eefi_token is not yet initialized, so address 0 is used, and the Distribute contract will think it should reward eth instead of a token
        rewards_eth = new Distribute(9, IERC20(0));
        eefi_token = new EEFIToken();
    }
```

3. In the `_rebase` function _(around line 171)_ the calculation of surplus seems strange and often returns 0 if `new_balance` is not high enough. I change the calculation, but I'm really not sure of what I've done, it would be better if you have a look.
```Solidity
// ! WARNING CALCULATION OF SURPLUS (commented line) SEEMS STRANGE: allways get 0
// uint256 surplus = new_supply.sub(old_supply).mul(new_balance).divDown(new_supply);

uint256 surplus = new_supply.sub(old_supply); // <- this is what I use, but I'm not sure
```

4. In the `_rebase` function _(around line 182)_ we transfer some ampl to the trader, but this will not work with current implementation of the `Mocktrader.sol`. Indeed the trader will itself try to `transferFrom` from the vault to itself, but it doesn't have the `allowance`

```Solidity
// _ampl_token.safeTransfer(address(trader), for_eefi.add(for_eth));
_ampl_token.approve(address(trader), for_eefi.add(for_eth)); // <- to fix the bug we remove transfer (as the trader already handle that) and increase allowance instead
```
_Trader related code is in `MockTrader.sol` in `sellAMPLForEth` & `sellAMPLForEEFI` at line 32 & 42_