### PR TITLE
Update ElasticVault.sol: Rewards distribution

### DIFF
--- a/contracts/ElasticVault.sol
+++ b/contracts/ElasticVault.sol
@@ -47,10 +47,10 @@ contract ElasticVault is AMPLRebaser, Wrapper, Ownable {
     - Deposit FEE_10000: .65% of EEFI minted to user upon initial deposit is delivered to Treasury 
     - Lock Time: AMPL deposited into vault is locked for 90 days; lock time applies to each new AMPL deposit
     - Trade Posiitve EEFI_100: Upon positive rebase 45% of new AMPL supply (based on total AMPL in vault) is sold and used to buy EEFI 
-    - Trade Positive OHM_100: Upon positive rebase 22% of the new AMPL supply (based on total AMPL in vault) is sold for OHM 
+    - Trade Positive OHM_100: Upon positive rebase 23% of the new AMPL supply (based on total AMPL in vault) is sold for OHM 
     - Trade Positive Treasury_100: Upon positive rebase 2% of new AMPL supply (based on total AMPL in vault) is deposited into Pioneer Vault I (Zeus/Apollo NFT stakers) // Send 2% to Treasury [OK]
     - Trade Positive Rewards_100: Upon positive rebase, send 55% of OHM rewards to users staking AMPL in vault 
-    - Trade Positive LP Staking_100: Upon positive rebase, send 30% of OHM rewards to users staking LP tokens (EEFI/OHM)
+    - Trade Positive LP Staking_100: Upon positive rebase, send 35% of OHM rewards to users staking LP tokens (EEFI/OHM)
     - Trade Neutral/Negative Rewards: Upon neutral/negative rebase, send 55% of EEFI rewards to users staking AMPL in vault
     - Trade Neutral/Negative LP Staking: Upon neutral/negative rebase, send 35% of EEFI rewards to users staking LP tokens (EEFI/OHM)
     - Minting Decay: If AMPL does not experience a positive rebase (increase in AMPL supply) for 45 days, do not mint EEFI, or distribute rewards to stakers 
@@ -64,11 +64,11 @@ contract ElasticVault is AMPLRebaser, Wrapper, Ownable {
     uint256 constant public DEPOSIT_FEE_10000 = 65;
     uint256 constant public LOCK_TIME = 90 days;
     uint256 constant public TRADE_POSITIVE_EEFI_100 = 45;
-    uint256 constant public TRADE_POSITIVE_OHM_100 = 22;
+    uint256 constant public TRADE_POSITIVE_OHM_100 = 23;
     uint256 constant public TRADE_POSITIVE_TREASURY_100 = 2;
     uint256 constant public TRADE_POSITIVE_OHM_REWARDS_100 = 55;
     uint256 constant public TRADE_NEUTRAL_NEG_EEFI_REWARDS_100 = 55;
-    uint256 constant public TRADE_POSITIVE_LPSTAKING_100 = 30; //Suggest creating 2 seperate sets of constants to account for positive and neutral/negative states (see comments below) [OK]
+    uint256 constant public TRADE_POSITIVE_LPSTAKING_100 = 35; 
     uint256 constant public TRADE_NEUTRAL_NEG_LPSTAKING_100 = 35;
     uint256 constant public TREASURY_EEFI_100 = 10;
     uint256 constant public MINTING_DECAY = 45 days;


### PR DESCRIPTION
Corrected rewards distribution:

-35% of OHM rewards provided to stakers, rather than 30 -23% of new AMPL supply sold for OHM