### PR TITLE
correction of the uint208 casting by modifying _ampletowaample function

### DIFF
--- a/contracts/ElasticVault.sol
+++ b/contracts/ElasticVault.sol
@@ -253,12 +253,12 @@ contract ElasticVault is AMPLRebaser, Wrapper, Ownable, ReentrancyGuard {
     */
     function makeDeposit(uint256 amount) _rebaseSynced() nonReentrant() external {
         ampl_token.safeTransferFrom(msg.sender, address(this), amount);
-        uint256 waampl = _ampleTowaample(amount);
+        uint208 waampl = _ampleTowaample(amount);
         // first deposit needs to initialize the linked list
         if(_deposits[msg.sender].nodeIdCounter == 0) {
             _deposits[msg.sender].initialize();
         }
-        _deposits[msg.sender].insertEnd(DepositsLinkedList.Deposit({amount: uint208(waampl), timestamp:uint48(block.timestamp)}));
+        _deposits[msg.sender].insertEnd(DepositsLinkedList.Deposit({amount: waampl, timestamp:uint48(block.timestamp)}));
 
         uint256 to_mint = amount.mul(10**9).divDown(EEFI_DEPOSIT_RATE);
         uint256 deposit_fee = to_mint.mul(DEPOSIT_FEE_10000).divDown(10000);

--- a/contracts/Wrapper.sol
+++ b/contracts/Wrapper.sol
@@ -26,6 +26,9 @@ abstract contract Wrapper {
         view
         returns (uint208)
     {
-        return uint208(amples.mul(MAX_WAAMPL_SUPPLY).divDown(ampl.totalSupply())); // maximum value is 10_000_000e12 and always fits into uint208
+        uint256 waamples = amples.mul(MAX_WAAMPL_SUPPLY).divDown(ampl.totalSupply());
+        // maximum value is 10_000_000e12 and always fits into uint208
+        require(waamples <= type(uint208).max, "Wrapper: waampl supply overflow");
+        return uint208(waamples); 
     }
 }

--- a/contracts/Wrapper.sol
+++ b/contracts/Wrapper.sol
@@ -24,8 +24,8 @@ abstract contract Wrapper {
     function _ampleTowaample(uint256 amples)
         internal
         view
-        returns (uint256)
+        returns (uint208)
     {
-        return amples.mul(MAX_WAAMPL_SUPPLY).divDown(ampl.totalSupply());
+        return uint208(amples.mul(MAX_WAAMPL_SUPPLY).divDown(ampl.totalSupply())); // maximum value is 10_000_000e12 and always fits into uint208
     }
 }


### PR DESCRIPTION
Proposal for "one additional safe casting operation to be performed during ElasticVault::makeDeposit operations to ensure that the casting operation is securely conducted."